### PR TITLE
Fix add to cart functionality

### DIFF
--- a/frontend/src/store/cartStore.js
+++ b/frontend/src/store/cartStore.js
@@ -25,8 +25,12 @@ export const useCartStore = defineStore('cart', {
     }
   },
   
-  actions: {
-    addItem(product, quantity = 1) {
+    actions: {
+      addToCart(product, quantity = 1) {
+        this.addItem(product, quantity);
+      },
+
+      addItem(product, quantity = 1) {
       const existingItem = this.items.find(item => item.productId === product._id);
       
       if (existingItem) {

--- a/frontend/src/views/ProductDetailView.vue
+++ b/frontend/src/views/ProductDetailView.vue
@@ -88,12 +88,14 @@
 import { ref, onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { useProductStore } from '@/store/productStore';
+import { useCartStore } from '@/store/cartStore';
 
 export default {
   name: 'ProductDetailView',
   setup() {
     const route = useRoute();
     const productStore = useProductStore();
+    const cartStore = useCartStore();
     const quantity = ref(1);
     const showDebug = ref(true); // 開啟調試模式
     
@@ -128,6 +130,7 @@ export default {
     };
     
     const addToCart = () => {
+      cartStore.addToCart(productStore.product, quantity.value);
       alert(`已將 ${quantity.value} 個 "${productStore.product.name}" 加入購物車`);
     };
     


### PR DESCRIPTION
## Summary
- connect product detail view to cart store
- add `addToCart` action alias in cart store

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_684296698924832588d6c15f9bf0dd31