### PR TITLE
Fix template download url

### DIFF
--- a/frontend/src/views/admin/BatchUploadView.vue
+++ b/frontend/src/views/admin/BatchUploadView.vue
@@ -284,7 +284,8 @@
       
       // 下載模板
       const downloadTemplate = () => {
-        const templateUrl = '/api/admin/download-template';
+        const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
+        const templateUrl = `${baseUrl}/api/admin/download-template`;
         window.open(templateUrl, '_blank');
       };
       


### PR DESCRIPTION
## Summary
- fix admin template download button to respect VITE_API_BASE_URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_684c4b61fbf48325b523d0746adc534b