### PR TITLE
Add customer creation and search

### DIFF
--- a/backend/controllers/customerController.js
+++ b/backend/controllers/customerController.js
@@ -1,0 +1,135 @@
+const User = require('../models/User');
+const Order = require('../models/Order');
+const nodemailer = require('nodemailer');
+
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: process.env.EMAIL_USER || 'jkruby886743@gmail.com',
+    pass: process.env.EMAIL_PASSWORD || 'qmyolojqsfgmhlad'
+  }
+});
+
+exports.createCustomer = async (req, res) => {
+  try {
+    const { name, email, phone, company } = req.body;
+    // 自動生成密碼，方便後續登入需求
+    const password = req.body.password || Math.random().toString(36).slice(-8);
+
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return res.status(400).json({ message: '該電子郵件已被註冊' });
+    }
+
+    const user = await User.create({ name, email, password, phone, company });
+
+    res.status(201).json({
+      _id: user._id,
+      name: user.name,
+      email: user.email,
+      phone: user.phone,
+      company: user.company
+    });
+  } catch (error) {
+    console.error('創建客戶錯誤:', error);
+    res.status(500).json({ message: '創建客戶失敗', error: error.message });
+  }
+};
+
+exports.listCustomers = async (req, res) => {
+  try {
+    const filter = { role: 'user' };
+    if (req.query.q) {
+      const q = req.query.q;
+      filter.$or = [
+        { name: { $regex: q, $options: 'i' } },
+        { email: { $regex: q, $options: 'i' } }
+      ];
+    }
+    const users = await User.find(filter).select('-password');
+    res.json(users);
+  } catch (error) {
+    console.error('獲取客戶列表錯誤:', error);
+    res.status(500).json({ message: '獲取客戶列表失敗', error: error.message });
+  }
+};
+
+exports.getCustomer = async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id).select('-password');
+    if (!user) {
+      return res.status(404).json({ message: '客戶不存在' });
+    }
+    const orders = await Order.find({ user: user._id });
+    res.json({ user, orders });
+  } catch (error) {
+    console.error('獲取客戶詳情錯誤:', error);
+    res.status(500).json({ message: '獲取客戶詳情失敗', error: error.message });
+  }
+};
+
+exports.updateCustomer = async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id);
+    if (!user) {
+      return res.status(404).json({ message: '客戶不存在' });
+    }
+
+    user.name = req.body.name || user.name;
+    user.email = req.body.email || user.email;
+    user.phone = req.body.phone || user.phone;
+    user.company = req.body.company || user.company;
+
+    if (req.body.addresses !== undefined) {
+      user.addresses = req.body.addresses;
+      user.markModified('addresses');
+    }
+
+    const updatedUser = await user.save();
+    res.json({ _id: updatedUser._id, name: updatedUser.name, email: updatedUser.email, phone: updatedUser.phone, company: updatedUser.company, addresses: updatedUser.addresses });
+  } catch (error) {
+    console.error('更新客戶資料錯誤:', error);
+    res.status(500).json({ message: '更新客戶資料失敗', error: error.message });
+  }
+};
+
+exports.deleteCustomer = async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id);
+    if (!user) {
+      return res.status(404).json({ message: '客戶不存在' });
+    }
+    await Order.deleteMany({ user: user._id });
+    await user.remove();
+    res.json({ message: '客戶已刪除' });
+  } catch (error) {
+    console.error('刪除客戶錯誤:', error);
+    res.status(500).json({ message: '刪除客戶失敗', error: error.message });
+  }
+};
+
+exports.sendEmailToCustomer = async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id);
+    if (!user) {
+      return res.status(404).json({ message: '客戶不存在' });
+    }
+
+    const { subject, message } = req.body;
+    if (!subject || !message) {
+      return res.status(400).json({ message: '請提供主旨和內容' });
+    }
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_USER || 'jkruby886743@gmail.com',
+      to: user.email,
+      subject,
+      text: message
+    });
+
+    res.json({ message: '已發送郵件給客戶' });
+  } catch (error) {
+    console.error('發送郵件錯誤:', error);
+    res.status(500).json({ message: '發送郵件失敗', error: error.message });
+  }
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -4,6 +4,7 @@ const dotenv = require('dotenv');
 const cookieParser = require('cookie-parser');
 const path = require('path');
 const productRoutes = require('./routes/productRoutes');
+const customerRoutes = require('./routes/customerRoutes');
 const authRoutes = require('./routes/authRoutes');
 const orderRoutes = require('./routes/orderRoutes');
 const favoriteRoutes = require('./routes/favoriteRoutes');
@@ -57,6 +58,7 @@ app.get('/api', (req, res) => {
 app.use('/api/products', productRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/orders', orderRoutes);
+app.use('/api/customers', customerRoutes);
 app.use('/api/favorites', favoriteRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/contact', contactRoutes);

--- a/backend/routes/customerRoutes.js
+++ b/backend/routes/customerRoutes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+const { protect, admin } = require('../middleware/authMiddleware');
+const {
+  listCustomers,
+  createCustomer,
+  getCustomer,
+  updateCustomer,
+  deleteCustomer,
+  sendEmailToCustomer
+} = require('../controllers/customerController');
+
+router.get('/', protect, admin, listCustomers);
+router.post('/', protect, admin, createCustomer);
+router.get('/:id', protect, admin, getCustomer);
+router.put('/:id', protect, admin, updateCustomer);
+router.delete('/:id', protect, admin, deleteCustomer);
+router.post('/:id/email', protect, admin, sendEmailToCustomer);
+
+module.exports = router;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -48,6 +48,7 @@
               
               <div v-show="showUserMenu" class="user-menu">
                 <router-link to="/profile" class="menu-item">個人中心</router-link>
+                <router-link v-if="isAdmin" to="/admin/customers" class="menu-item">客戶中心</router-link>
                 <router-link v-if="isAdmin" to="/admin/batch-upload" class="menu-item">批量上傳</router-link>
                 <a href="#" @click.prevent="logout" class="menu-item">登出</a>
               </div>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -86,6 +86,12 @@ const router = createRouter({
       name: 'admin-batch-upload',
       component: () => import('../views/admin/BatchUploadView.vue'),
       meta: { requiresAuth: true, requiresAdmin: true }
+    },
+    {
+      path: '/admin/customers',
+      name: 'admin-customers',
+      component: () => import('../views/admin/CustomerCenterView.vue'),
+      meta: { requiresAuth: true, requiresAdmin: true }
     }
   ]
 });

--- a/frontend/src/store/customerStore.js
+++ b/frontend/src/store/customerStore.js
@@ -1,0 +1,49 @@
+import { defineStore } from 'pinia';
+import axios from 'axios';
+
+export const useCustomerStore = defineStore('customers', {
+  state: () => ({
+    customers: [],
+    loading: false,
+    error: null,
+  }),
+
+  actions: {
+    async fetchCustomers(query = '') {
+      this.loading = true;
+      try {
+        const response = await axios.get('/api/customers', {
+          params: query ? { q: query } : {}
+        });
+        this.customers = response.data;
+        this.error = null;
+      } catch (error) {
+        console.error('獲取客戶列表失敗:', error);
+        this.error = '無法獲取客戶列表';
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async createCustomer(data) {
+      try {
+        const response = await axios.post('/api/customers', data);
+        this.customers.push(response.data);
+        return true;
+      } catch (error) {
+        console.error('創建客戶失敗:', error);
+        return false;
+      }
+    },
+
+    async deleteCustomer(id) {
+      try {
+        await axios.delete(`/api/customers/${id}`);
+        this.customers = this.customers.filter(c => c._id !== id);
+      } catch (error) {
+        console.error('刪除客戶失敗:', error);
+      }
+    },
+  },
+});
+

--- a/frontend/src/views/admin/CustomerCenterView.vue
+++ b/frontend/src/views/admin/CustomerCenterView.vue
@@ -1,0 +1,199 @@
+<template>
+  <div class="customer-center container">
+    <h1 class="page-title">客戶中心</h1>
+
+    <div class="actions">
+      <input
+        type="text"
+        v-model="search"
+        class="search-input"
+        placeholder="搜尋客戶..."
+        @input="searchCustomers"
+      >
+      <button class="add-btn" @click="toggleForm">新增客戶</button>
+    </div>
+
+    <form v-if="showForm" @submit.prevent="create" class="customer-form">
+      <div class="form-group">
+        <label>姓名</label>
+        <input v-model="form.name" required>
+      </div>
+      <div class="form-group">
+        <label>Email</label>
+        <input v-model="form.email" type="email" required>
+      </div>
+      <div class="form-group">
+        <label>電話</label>
+        <input v-model="form.phone">
+      </div>
+      <div class="form-group">
+        <label>公司</label>
+        <input v-model="form.company">
+      </div>
+      <div class="form-actions">
+        <button type="submit">建立</button>
+        <button type="button" class="cancel-btn" @click="toggleForm">取消</button>
+      </div>
+    </form>
+
+    <div v-if="loading" class="loading">載入中...</div>
+    <div v-else>
+      <table class="customer-table">
+        <thead>
+          <tr>
+            <th>姓名</th>
+            <th>Email</th>
+            <th>電話</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="customer in customers" :key="customer._id">
+            <td>{{ customer.name }}</td>
+            <td>{{ customer.email }}</td>
+            <td>{{ customer.phone }}</td>
+            <td>
+              <button @click="deleteCustomer(customer._id)">刪除</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import { computed, onMounted, reactive, ref } from 'vue';
+import { useCustomerStore } from '@/store/customerStore';
+
+export default {
+  name: 'CustomerCenterView',
+  setup() {
+    const store = useCustomerStore();
+    const customers = computed(() => store.customers);
+    const loading = computed(() => store.loading);
+
+    const search = ref('');
+    const showForm = ref(false);
+    const form = reactive({ name: '', email: '', phone: '', company: '' });
+
+    onMounted(() => {
+      store.fetchCustomers();
+    });
+
+    const searchCustomers = () => {
+      store.fetchCustomers(search.value);
+    };
+
+    const toggleForm = () => {
+      showForm.value = !showForm.value;
+    };
+
+    const create = async () => {
+      const payload = {
+        name: form.name,
+        email: form.email,
+        phone: form.phone,
+        company: form.company,
+      };
+      const success = await store.createCustomer(payload);
+      if (success) {
+        showForm.value = false;
+        form.name = '';
+        form.email = '';
+        form.phone = '';
+        form.company = '';
+      }
+    };
+
+    const deleteCustomer = async (id) => {
+      if (confirm('確定刪除此客戶?')) {
+        await store.deleteCustomer(id);
+      }
+    };
+
+    return {
+      customers,
+      loading,
+      search,
+      searchCustomers,
+      showForm,
+      form,
+      toggleForm,
+      create,
+      deleteCustomer,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.customer-center {
+  padding: 40px 0;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.search-input {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  margin-right: 10px;
+}
+
+.add-btn {
+  padding: 10px 20px;
+}
+
+.customer-form {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  padding: 20px;
+  margin-bottom: 30px;
+}
+
+.form-group {
+  margin-bottom: 15px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.cancel-btn {
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+.customer-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.customer-table th,
+.customer-table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add ability to create customers and search existing ones
- register POST `/api/customers` route
- improve admin customer page styling and functionality
- fix customer creation and remove password requirement

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_684c481737108325963a2986e4820b66